### PR TITLE
Reset title when starting new game

### DIFF
--- a/SwiftUI/Project8/Project8 Watch App/ContentView.swift
+++ b/SwiftUI/Project8/Project8 Watch App/ContentView.swift
@@ -75,6 +75,7 @@ struct ContentView: View {
 
         // remove all their previous answers and reset the text
         correctValues.removeAll()
+        title = "Safe Crack"
 
         // pick the first number to guess
         pickNumber()


### PR DESCRIPTION
Added line to reset title to "Safe Crack" when starting a new game. The comment mentioned it should do that, but the line was missing. 

TODO: The code snippet on page 309 of _Hacking with watchOS_ should also be updated.

![Hacking with watchOS Page 309](https://github.com/twostraws/watchOS/assets/2607653/cd30c217-ecd0-46e1-81a4-80798e2dbeba)
